### PR TITLE
Removes trailing period after end of document.

### DIFF
--- a/DataCarpentry_generic.tex
+++ b/DataCarpentry_generic.tex
@@ -215,4 +215,4 @@ This workshop could not have been developed or taught without the support of sev
 
 We are also grateful to Software Carpentry and the Mozilla Science Lab for guidance on materials development and administrative support.
 
-\end{document}.
+\end{document}


### PR DESCRIPTION
Tiny change.
